### PR TITLE
Make `env/get` accept parsing functions with any error type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `glenvy/env`
+  - The parsing function passed to `get` now accepts any error type in the `Result`.
+
 ## [1.0.1] - 2024-07-31
 
 ### Changed

--- a/src/glenvy/env.gleam
+++ b/src/glenvy/env.gleam
@@ -30,10 +30,10 @@ pub fn get_string(name: String) -> Result(String, Error) {
 ///
 /// Uses the provided `parser` to parse the value.
 ///
-/// Returns `Error(FailedToParse)` if the provided `parser` returns an error. 
+/// Returns `Error(FailedToParse)` if the provided `parser` returns an error.
 pub fn get(
   name: String,
-  parser parse: fn(String) -> Result(a, b),
+  parser parse: fn(String) -> Result(a, err),
 ) -> Result(a, Error) {
   use value <- try(get_string(name))
 

--- a/src/glenvy/env.gleam
+++ b/src/glenvy/env.gleam
@@ -30,10 +30,10 @@ pub fn get_string(name: String) -> Result(String, Error) {
 ///
 /// Uses the provided `parser` to parse the value.
 ///
-/// Returns `Error(FailedToParse)` if the provided `parser` returns `Error(Nil)`.
+/// Returns `Error(FailedToParse)` if the provided `parser` returns an error. 
 pub fn get(
   name: String,
-  parser parse: fn(String) -> Result(a, Nil),
+  parser parse: fn(String) -> Result(a, b),
 ) -> Result(a, Error) {
   use value <- try(get_string(name))
 


### PR DESCRIPTION
I love the env.get function! Just thought it would be a little more versatile to allow any Error type, not just Error(Nil), since the error value is never read anyway. I ran all tests and they still pass. Any thoughts?